### PR TITLE
Removed max errbot version limit.

### DIFF
--- a/weatherinfo.plug
+++ b/weatherinfo.plug
@@ -10,5 +10,3 @@ version = 3
 
 [Errbot]
 min = 4.2.2
-max = 4.2.2
-


### PR DESCRIPTION
Works well with errbot version 4.3.7.